### PR TITLE
fix: bump fast-uri, postcss, and nanoid in both lockfiles

### DIFF
--- a/example/webpack/pnpm-lock.yaml
+++ b/example/webpack/pnpm-lock.yaml
@@ -304,8 +304,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -834,7 +834,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -955,7 +955,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastest-levenshtein@1.0.16: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -498,8 +498,8 @@ packages:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -535,8 +535,8 @@ packages:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
 
-  postcss@8.5.18:
-    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prettier@3.8.2:
@@ -1053,7 +1053,7 @@ snapshots:
 
   mrmime@2.0.1: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.18: {}
 
   obug@2.1.4: {}
 
@@ -1075,9 +1075,9 @@ snapshots:
 
   pngjs@7.0.0: {}
 
-  postcss@8.5.18:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -1140,7 +1140,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.18
+      postcss: 8.5.26
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
Fixes Dependabot alert [#33](https://github.com/ustclug-dev/brotli-dec-wasm/security/dependabot/33), plus three advisories that `pnpm audit` reports on the root lockfile.

## Changes

| Lockfile | Package | Version | Advisory |
| --- | --- | --- | --- |
| `example/webpack/pnpm-lock.yaml` | fast-uri | 3.1.4 → 3.1.5 | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) (CVE-2026-18446), high |
| `pnpm-lock.yaml` | postcss | 8.5.18 → 8.5.26 | [GHSA-6g55-p6wh-862q](https://github.com/advisories/GHSA-6g55-p6wh-862q) incomplete-fix follow-up, moderate |
| `pnpm-lock.yaml` | nanoid | 3.3.12 → 3.3.18 | two infinite-loop advisories, high |

All three are development-scope transitive dependencies: fast-uri through `webpack-cli > ajv`, postcss and nanoid through `vite`. No `package.json` change is needed, since every declared range already admits the patched version.

## Why Dependabot could not do this

The alert 33 update job [failed](https://github.com/ustclug-dev/brotli-dec-wasm/actions/runs/31057729931) because its job definition carries `allowed-updates: [{dependency-type: direct}]` and `update-subdependencies: false`. fast-uri is an indirect dependency, so Dependabot had nothing it was allowed to change.

## Verification

- `pnpm audit` is clean on both lockfiles.
- `pnpm install --frozen-lockfile` succeeds at the repo root and in `example/webpack`.

One note for whoever touches `example/webpack` next: running pnpm from inside that directory makes pnpm walk up to the root `pnpm-workspace.yaml`, treat `example/webpack` as a workspace member, and write its resolutions into the root lockfile rather than `example/webpack/pnpm-lock.yaml`. Pass `--ignore-workspace` there. Running pnpm at the repo root is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)