### PR TITLE
deps: bump brotli-decompressor to 5.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `brotli-decompressor` to 5.0.3. A stream whose padding bits after the final metablock are not zero now
+  fails with `BROTLI_DECODER_ERROR_FORMAT_PADDING_2` instead of decoding, which is what RFC 7932 section 9.2 and
+  the reference C implementation require. Streams from standard encoders are unaffected.
+
 ## [2.3.2] - 2026-03-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",


### PR DESCRIPTION
Three patch releases. Only one of them changes anything a user of this package can observe.

## What is in 5.0.1 through 5.0.3

| File | Change |
| --- | --- |
| `src/decode.rs` | 5.0.1: `BrotliJumpToByteBoundary` failing set `result` without a `break`, so control fell through to `BROTLI_STATE_DONE` and `WriteRingBuffer`'s return value overwrote it. The `PADDING_2` error was silently dropped. |
| `src/writer.rs` | `DecompressorWriter::new_with_custom_dictionary` uses 4096 when `buffer_size` is 0. This package does not use `writer`. |
| `src/lib.rs` | `forbid(unsafe_code)` on the default build. |
| `Cargo.toml` | `alloc-no-stdlib` widened to `>=2.0.4, <4`, `seccomp` forwards `alloc-no-stdlib/unsafe`. |

Everything else in the diff is `src/bin/` and tests.

## The observable change

A stream whose padding bits after the final metablock are not zero used to decode. It now fails. Measured on the same stream, produced by `zlib.brotliCompressSync` with the high bit of the last byte flipped:

| Decoder | Result |
| --- | --- |
| brotli-decompressor 5.0.0 | `ResultSuccess`, 207 bytes out |
| brotli-decompressor 5.0.3 | `ResultFailure`, `BROTLI_DECODER_ERROR_FORMAT_PADDING_2` |
| node `zlib` (reference C brotli) | `ERR__ERROR_FORMAT_PADDING_2` |

So 5.0.3 moves toward the reference implementation, and RFC 7932 section 9.2 requires the padding to be zero. `src/err.rs` already exports `BROTLI_DECODER_ERROR_FORMAT_PADDING_2 = 15`, so the code reaches callers without any change here.

Streams from brotli CLI, `CompressionStream`, and node `zlib` all pad with zeros and are unaffected. Only hand-built or corrupted input hits this.

## Scope

`cargo update -p brotli-decompressor` only, so `alloc-no-stdlib` stays at 2.0.4, `alloc-stdlib` at 0.2.2, and `wasm-bindgen` at 0.2.114. `Cargo.toml` needs no edit because the declared `"5.0.0"` is a caret range. A bare `cargo update` would additionally pull `wasm-bindgen` 0.2.127 and `alloc-stdlib` 0.2.4, which this PR deliberately does not do.

## Verification

- `cargo fmt --check` and `cargo clippy --all-features -- --no-deps -Dwarnings`
- `wasm-pack build -t web`, WASM 204732 to 204724 bytes
- `pnpm run test`, 7/7
- `cargo audit` clean on the resulting lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)