### PR TITLE
ci: pin wasm-pack to wasm-pack-version.txt

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,12 @@ jobs:
           node-version: 24
           cache: pnpm
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        run: |
+          version="$(cut -d ' ' -f 2 wasm-pack-version.txt)"
+          dir="wasm-pack-v$version-x86_64-unknown-linux-musl"
+          curl -sSfL -o "$RUNNER_TEMP/wasm-pack.tar.gz" "https://github.com/wasm-bindgen/wasm-pack/releases/download/v$version/$dir.tar.gz"
+          tar xzf "$RUNNER_TEMP/wasm-pack.tar.gz" -C "$RUNNER_TEMP"
+          echo "$RUNNER_TEMP/$dir" >> "$GITHUB_PATH"
       - run: pnpm install
       - run: pnpm run format:check
       - run: pnpm run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,9 @@ package exposes a small ESM wrapper that initializes the WASM module once.
 3. `pnpm run minify` minifies the generated WASM JS glue and the package entry.
 4. The published package exports the default wrapper at `.` and raw WASM-pack
    files at `./web` and `./web/bg.wasm`.
+5. `wasm-pack-version.txt` holds the `wasm-pack --version` output that CI
+   installs. Edit it to move the pinned version, and publish with that same
+   version so the released WASM matches what CI builds.
 
 ## Working Rules
 


### PR DESCRIPTION
`wasm-pack-version.txt` says `wasm-pack 0.14.0`, but nothing in the repo read it. CI installed wasm-pack with

```
curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
```

and that script hardcodes `UPDATE_ROOT="https://github.com/rustwasm/wasm-pack/releases/download/v0.13.1"` on line 18. The installer has not been updated since 0.13.1, so CI has been building with 0.13.1 while the published package was built with 0.14.0. The two differ by 12 bytes of WASM.

## Change

Read the version out of the file and fetch that release directly:

```yaml
- name: Install wasm-pack
  run: |
    version="$(cut -d ' ' -f 2 wasm-pack-version.txt)"
    dir="wasm-pack-v$version-x86_64-unknown-linux-musl"
    curl -sSfL -o "$RUNNER_TEMP/wasm-pack.tar.gz" "https://github.com/wasm-bindgen/wasm-pack/releases/download/v$version/$dir.tar.gz"
    tar xzf "$RUNNER_TEMP/wasm-pack.tar.gz" -C "$RUNNER_TEMP"
    echo "$RUNNER_TEMP/$dir" >> "$GITHUB_PATH"
```

The file holds `wasm-pack --version` output, so `cut -d ' ' -f 2` gives `0.14.0`.

There is no separate version-check step. The version is derived from the file, so a check could only fire when the file's format is broken, and `curl -sSfL` already fails loudly on the resulting 404.

`AGENTS.md` gains a Build Flow note that the file now controls what CI installs, and that publishing should use the same version.

## Verification

Ran the step locally with `RUNNER_TEMP` and `GITHUB_PATH` stubbed: version parses to `0.14.0`, the URL resolves, the tarball extracts an executable linux musl binary, and the `GITHUB_PATH` entry points at it. With the file set to a nonexistent `9.9.9`, curl exits 56 on a 404 and the step fails. `pnpm run format:check` passes.

## Note

The target is hardcoded to `x86_64-unknown-linux-musl` because `runs-on` is pinned to `ubuntu-24.04`. Moving to an arm runner would 404 at the download rather than quietly install the wrong thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)